### PR TITLE
Fix calls for utide to use the new function names from upstream.

### DIFF
--- a/pyseidon/adcpClass/functionsAdcp.py
+++ b/pyseidon/adcpClass/functionsAdcp.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from datetime import timedelta
 from miscellaneous import *
 from BP_tools import *
-from utide import ut_solv, ut_reconstr
+from utide import solve, reconstruct
 import time
 from miscellaneous import mattime_to_datetime 
 
@@ -324,11 +324,11 @@ class FunctionsAdcp:
                      or time index as an integer
           - t_end = end time, as a string ('yyyy-mm-ddThh:mm:ss'),
                     or time index as an integer
-          - elevation=True means that ut_solv will be done for elevation.
-          - velocity=True means that ut_solv will be done for velocity.
+          - elevation=True means that `solve' will be done for elevation.
+          - velocity=True means that `solve' will be done for velocity.
 
         Options:
-        Options are the same as for ut_solv, which are shown below with
+        Options are the same as for `solve', which are shown below with
         their default values:
             conf_int=True; cnstit='auto'; notrend=0; prefilt=[]; nodsatlint=0;
             nodsatnone=0; gwchlint=0; gwchnone=0; infer=[]; inferaprx=0;
@@ -337,7 +337,7 @@ class FunctionsAdcp:
             ordercnstit=[]; runtimedisp='yyy'
 
         *Notes*
-        For more detailed information about ut_solv, please see
+        For more detailed information about `solve', please see
         https://github.com/wesleybowman/UTide
 
         '''
@@ -365,7 +365,7 @@ class FunctionsAdcp:
                 v = v[argtime[:]]
 
             lat = self._var.lat
-            harmo = ut_solv(time, u, v, lat, **kwargs)
+            harmo = solve(time, u, v, lat, **kwargs)
 
         if elevation:
             time = self._var.matlabTime[:]
@@ -376,7 +376,7 @@ class FunctionsAdcp:
                 el = el[argtime[:]]
 
             lat = self._var.lat
-            harmo = ut_solv(time, el, [], lat, **kwargs)
+            harmo = solve(time, el, [], lat, **kwargs)
             #Write meta-data only if computed over all the elements
 
             return harmo
@@ -386,12 +386,12 @@ class FunctionsAdcp:
         """
         This function reconstructs the velocity components or the surface elevation
         from harmonic coefficients.
-        Harmonic_reconstruction calls ut_reconstr. This function assumes harmonics
-        (ut_solv) has already been executed.
+        Harmonic_reconstruction calls `reconstruct'. This function assumes harmonics
+        (`solve') has already been executed.
 
         Inputs:
           - Harmo = harmonic coefficient from harmo_analysis
-          - elevation =True means that ut_reconstr will be done for elevation.
+          - elevation =True means that `reconstruct' will be done for elevation.
           - velocity =True means that ut_reconst will be done for velocity.
           - time_ind = time indices to process, list of integers
         
@@ -399,12 +399,12 @@ class FunctionsAdcp:
           - Reconstruct = reconstructed signal, dictionary
 
         Utide's options:
-        Options are the same as for ut_reconstr, which are shown below with
+        Options are the same as for `reconstruct', which are shown below with
         their default values:
             cnstit = [], minsnr = 2, minpe = 0
 
         *Notes*
-        For more detailed information about ut_reconstr, please see
+        For more detailed information about `reconstruct', please see
         https://github.com/wesleybowman/UTide
         """
         debug = (debug or self._debug)
@@ -412,11 +412,11 @@ class FunctionsAdcp:
         #TR_comments: Add debug flag in Utide: debug=self._debug
         Reconstruct = {}
         if velocity:
-            U_recon, V_recon = ut_reconstr(time,harmo)
+            U_recon, V_recon = reconstruct(time,harmo)
             Reconstruct['U'] = U_recon
             Reconstruct['V'] = V_recon
         if elevation:
-            elev_recon, _ = ut_reconstr(time,harmo)
+            elev_recon, _ = reconstruct(time,harmo)
             Reconstruct['el'] = elev_recon
         return Reconstruct  
 

--- a/pyseidon/adcpClass/rawADCPclass.py
+++ b/pyseidon/adcpClass/rawADCPclass.py
@@ -2,7 +2,7 @@ from __future__ import division
 import numpy as np
 import sys
 sys.path.append('/home/wesley/github/UTide/')
-from utide import ut_solv, ut_reconstr
+from utide import solve, reconstruct
 #from shortest_element_path import shortest_element_path
 #import matplotlib.pyplot as plt
 #import matplotlib.tri as Tri

--- a/pyseidon/fvcomClass/functionsFvcom.py
+++ b/pyseidon/fvcomClass/functionsFvcom.py
@@ -12,7 +12,7 @@ from datetime import timedelta
 from interpolation_utils import *
 from miscellaneous import *
 from BP_tools import *
-from utide import ut_solv, ut_reconstr
+from utide import solve, reconstruct
 import time
 import matplotlib.tri as Tri
 from pydap.exceptions import ServerError
@@ -939,11 +939,11 @@ class FunctionsFvcom:
           - time_ind = time indices to work in, list of integers
           - t_start = start time, as a string ('yyyy-mm-ddThh:mm:ss'), or time index as an integer
           - t_end = end time, as a string ('yyyy-mm-ddThh:mm:ss'), or time index as an integer
-          - elevation=True means that ut_solv will be done for elevation.
-          - velocity=True means that ut_solv will be done for velocity.
+          - elevation=True means that `solve 'will be done for elevation.
+          - velocity=True means that `solve' will be done for velocity.
 
         Utide's options:
-        Options are the same as for ut_solv, which are shown below with
+        Options are the same as for `solve', which are shown below with
         their default values:
             conf_int=True; cnstit='auto'; notrend=0; prefilt=[]; nodsatlint=0;
             nodsatnone=0; gwchlint=0; gwchnone=0; infer=[]; inferaprx=0;
@@ -952,7 +952,7 @@ class FunctionsFvcom:
             ordercnstit=[]; runtimedisp='yyy'
 
         *Notes*
-        For more detailed information about ut_solv, please see
+        For more detailed information about `solve', please see
         https://github.com/wesleybowman/UTide
 
         """
@@ -987,7 +987,7 @@ class FunctionsFvcom:
                 v = v[argtime[:]]
 
             lat = self._grid.lat[index]
-            harmo = ut_solv(time, u, v, lat, **kwarg)
+            harmo = solve(time, u, v, lat, **kwarg)
 
         if elevation:
             time = self._var.matlabTime[:]
@@ -1003,7 +1003,7 @@ class FunctionsFvcom:
                 el = el[argtime[:]]
 
             lat = self._grid.lat[index]
-            harmo = ut_solv(time, el, [], lat, **kwarg)
+            harmo = solve(time, el, [], lat, **kwarg)
             #Write meta-data only if computed over all the elements
 
             return harmo
@@ -1013,12 +1013,12 @@ class FunctionsFvcom:
         """
         This function reconstructs the velocity components or the surface elevation
         from harmonic coefficients.
-        Harmonic_reconstruction calls ut_reconstr. This function assumes harmonics
-        (ut_solv) has already been executed.
+        Harmonic_reconstruction calls `reconstruct'. This function assumes harmonics
+        (`solve') has already been executed.
 
         Inputs:
           - Harmo = harmonic coefficient from harmo_analysis
-          - elevation =True means that ut_reconstr will be done for elevation.
+          - elevation =True means that `reconstruct' will be done for elevation.
           - velocity =True means that ut_reconst will be done for velocity.
           - time_ind = time indices to process, list of integers
         
@@ -1026,12 +1026,12 @@ class FunctionsFvcom:
           - Reconstruct = reconstructed signal, dictionary
 
         Options:
-        Options are the same as for ut_reconstr, which are shown below with
+        Options are the same as for `reconstruct', which are shown below with
         their default values:
             cnstit = [], minsnr = 2, minpe = 0
 
         *Notes*
-        For more detailed information about ut_reconstr, please see
+        For more detailed information about `reconstruct', please see
         https://github.com/wesleybowman/UTide
 
         """
@@ -1040,10 +1040,10 @@ class FunctionsFvcom:
         #TR_comments: Add debug flag in Utide: debug=self._debug
         Reconstruct = {}
         if velocity:
-            U_recon, V_recon = ut_reconstr(time,harmo)
+            U_recon, V_recon = reconstruct(time,harmo)
             Reconstruct['U'] = U_recon
             Reconstruct['V'] = V_recon
         if elevation:
-            elev_recon, _ = ut_reconstr(time,harmo)
+            elev_recon, _ = reconstruct(time,harmo)
             Reconstruct['el'] = elev_recon
         return Reconstruct  

--- a/pyseidon/fvcomClass/fvcomClass.py
+++ b/pyseidon/fvcomClass/fvcomClass.py
@@ -5,7 +5,6 @@
 from __future__ import division
 import numpy as np
 import sys
-from utide import ut_solv, ut_reconstr
 #TR comment: 2 alternatives
 import netCDF4 as nc
 from scipy.io import netcdf

--- a/pyseidon/stationClass/functionsStation.py
+++ b/pyseidon/stationClass/functionsStation.py
@@ -7,7 +7,7 @@ import sys
 import numexpr as ne
 from miscellaneous import *
 from BP_tools import *
-from utide import ut_solv, ut_reconstr
+from utide import solve, reconstruct
 import time
 
 # Custom error
@@ -387,11 +387,11 @@ class FunctionsStation:
           - t_start = start time, as string ('yyyy-mm-ddThh:mm:ss'), or time index as an integer
           - t_end = end time, as a string ('yyyy-mm-ddThh:mm:ss'), or time index as an integer
           - time_ind = time indices to work in, list of integers
-          - elevation=True means that ut_solv will be done for elevation.
-          - velocity=True means that ut_solv will be done for velocity.
+          - elevation=True means that `solve' will be done for elevation.
+          - velocity=True means that `solve' will be done for velocity.
 
         Utide's options:
-        Options are the same as for ut_solv, which are shown below with
+        Options are the same as for `solve', which are shown below with
         their default values:
             conf_int=True; cnstit='auto'; notrend=0; prefilt=[]; nodsatlint=0;
             nodsatnone=0; gwchlint=0; gwchnone=0; infer=[]; inferaprx=0;
@@ -400,7 +400,7 @@ class FunctionsStation:
             ordercnstit=[]; runtimedisp='yyy'
 
         *Notes*
-        For more detailed information about ut_solv, please see
+        For more detailed information about `solve', please see
         https://github.com/wesleybowman/UTide
 
         """
@@ -431,7 +431,7 @@ class FunctionsStation:
                 v = v[argtime[:]]
 
             lat = self._grid.lat[index]
-            harmo = ut_solv(time, u, v, lat, **kwarg)
+            harmo = solve(time, u, v, lat, **kwarg)
 
         if elevation:
             time = self._var.matlabTime[:]
@@ -442,7 +442,7 @@ class FunctionsStation:
                 el = el[argtime[:]]
 
             lat = self._grid.lat[index]
-            harmo = ut_solv(time, el, [], lat, **kwarg)
+            harmo = solve(time, el, [], lat, **kwarg)
             #Write meta-data only if computed over all the elements
 
             return harmo
@@ -452,12 +452,12 @@ class FunctionsStation:
         """
         This function reconstructs the velocity components or the surface elevation
         from harmonic coefficients.
-        Harmonic_reconstruction calls ut_reconstr. This function assumes harmonics
-        (ut_solv) has already been executed.
+        Harmonic_reconstruction calls `reconstruct'. This function assumes harmonics
+        (`solve') has already been executed.
 
         Inputs:
           - Harmo = harmonic coefficient from harmo_analysis
-          - elevation =True means that ut_reconstr will be done for elevation.
+          - elevation =True means that `reconstruct' will be done for elevation.
           - velocity =True means that ut_reconst will be done for velocity.
           - time_ind = time indices to process, list of integers
         
@@ -465,12 +465,12 @@ class FunctionsStation:
           - Reconstruct = reconstructed signal, dictionary
 
         Options:
-        Options are the same as for ut_reconstr, which are shown below with
+        Options are the same as for `reconstruct', which are shown below with
         their default values:
             cnstit = [], minsnr = 2, minpe = 0
 
         *Notes*
-        For more detailed information about ut_reconstr, please see
+        For more detailed information about `reconstruct', please see
         https://github.com/wesleybowman/UTide
 
         """
@@ -479,10 +479,10 @@ class FunctionsStation:
         #TR_comments: Add debug flag in Utide: debug=self._debug
         Reconstruct = {}
         if velocity:
-            U_recon, V_recon = ut_reconstr(time,harmo)
+            U_recon, V_recon = reconstruct(time,harmo)
             Reconstruct['U'] = U_recon
             Reconstruct['V'] = V_recon
         if elevation:
-            elev_recon, _ = ut_reconstr(time,harmo)
+            elev_recon, _ = reconstruct(time,harmo)
             Reconstruct['el'] = elev_recon
         return Reconstruct  

--- a/pyseidon/tidegaugeClass/functionsTidegauge.py
+++ b/pyseidon/tidegaugeClass/functionsTidegauge.py
@@ -3,7 +3,7 @@
 
 from __future__ import division
 import numpy as np
-from utide import ut_solv, ut_reconstr
+from utide import solve, reconstruct
 from miscellaneous import mattime_to_datetime 
 
 class FunctionsTidegauge:
@@ -30,7 +30,7 @@ class FunctionsTidegauge:
           - time_ind = time indices to work in, list of integers
 
         Utide's options:
-        Options are the same as for ut_solv, which are shown below with
+        Options are the same as for `solve', which are shown below with
         their default values:
             conf_int=True; cnstit='auto'; notrend=0; prefilt=[]; nodsatlint=0;
             nodsatnone=0; gwchlint=0; gwchnone=0; infer=[]; inferaprx=0;
@@ -39,10 +39,10 @@ class FunctionsTidegauge:
             ordercnstit=[]; runtimedisp='yyy'
 
         *Notes*
-        For more detailed information about ut_solv, please see
+        For more detailed information about `solve', please see
         https://github.com/wesleybowman/UTide
         """
-        harmo = ut_solv(self._var.matlabTime[time_ind],
+        harmo = solve(self._var.matlabTime[time_ind],
                        self._var.el, [],
                        self._var.lat, **kwarg)
         return harmo
@@ -51,8 +51,8 @@ class FunctionsTidegauge:
         """
         This function reconstructs the velocity components or the surface elevation
         from harmonic coefficients.
-        Harmonic_reconstruction calls ut_reconstr. This function assumes harmonics
-        (ut_solv) has already been executed.
+        Harmonic_reconstruction calls `reconstruct'. This function assumes harmonics
+        (`solve') has already been executed.
 
         Inputs:
           - Harmo = harmonic coefficient from harmo_analysis
@@ -64,16 +64,16 @@ class FunctionsTidegauge:
           - time_ind = time indices to process, list of integers
 
         Utide's options:
-        Options are the same as for ut_reconstr, which are shown below with
+        Options are the same as for `reconstruct', which are shown below with
         their default values:
             cnstit = [], minsnr = 2, minpe = 0
 
         *Notes*
-        For more detailed information about ut_reconstr, please see
+        For more detailed information about `reconstruct', please see
         https://github.com/wesleybowman/UTide
         """
         time = self._var.matlabTime[time_ind]
-        ts_recon, _ = ut_reconstr(time, harmo, **kwarg)
+        ts_recon, _ = reconstruct(time, harmo, **kwarg)
         return ts_recon
 
     def mattime2datetime(self, mattime, debug=False):

--- a/pyseidon/tidegaugeClass/tidegaugeClass.py
+++ b/pyseidon/tidegaugeClass/tidegaugeClass.py
@@ -5,7 +5,6 @@ from __future__ import division
 import numpy as np
 import scipy.io as sio
 import sys
-from utide import ut_solv, ut_reconstr
 
 #Add local path to utilities
 sys.path.append('../utilities/')

--- a/pyseidon/validationClass/validationClass.py
+++ b/pyseidon/validationClass/validationClass.py
@@ -7,7 +7,7 @@ import cPickle as pkl
 
 #Quick fix
 from scipy.io import savemat
-from utide import ut_solv
+from utide import solve
 
 #Local import
 from compareData import *
@@ -27,7 +27,6 @@ from pyseidon_error import PyseidonError
 
 class Validation:
     """
-<<<<<<< HEAD
     **Validation class/structure**
 
     Class structured as follows: ::
@@ -204,14 +203,14 @@ class Validation:
             va =  self.Variables.struct['obs_timeseries']['va'][:]
             el =  self.Variables.struct['obs_timeseries']['elev'] [:]
 
-            self.Variables.obs.velCoef = ut_solv(time, ua, va, lat,
+            self.Variables.obs.velCoef = solve(time, ua, va, lat,
                                          #cnstit=ut_constits, rmin=0.95, notrend=True,
                                          cnstit='auto', rmin=0.95, notrend=True,
                                          method='ols', nodiagn=True, linci=True,
                                          coef_int=True)
 
 
-            self.Variables.obs.elCoef = ut_solv(time, el, [], lat,
+            self.Variables.obs.elCoef = solve(time, el, [], lat,
                                         #cnstit=ut_constits, rmin=0.95, notrend=True,
                                         cnstit='auto', rmin=0.95, notrend=True,
                                         method='ols', nodiagn=True, linci=True,
@@ -222,7 +221,7 @@ class Validation:
             lat = self.Variables.struct['lat']
             el =  self.Variables.struct['obs_timeseries']['elev'] [:]
 
-            self.Variables.obs.elCoef = ut_solv(time, el, [], lat,
+            self.Variables.obs.elCoef = solve(time, el, [], lat,
                                         #cnstit=ut_constits, notrend=True,
                                         cnstit='auto', notrend=True,
                                         rmin=0.95, method='ols', nodiagn=True,
@@ -236,14 +235,14 @@ class Validation:
             lat = self.Variables.struct['lat']
             el =  self.Variables.struct['mod_timeseries']['elev'][:]
 
-            self.Variables.sim.elCoef = ut_solv(time, el, [], lat,
+            self.Variables.sim.elCoef = solve(time, el, [], lat,
                              #cnstit=ut_constits, rmin=0.95, notrend=True,
                              cnstit='auto', rmin=0.95, notrend=True,
                              method='ols', nodiagn=True, linci=True, conf_int=True)
             if self.Variables._obstype=='adcp':
                 ua =  self.Variables.struct['mod_timeseries']['ua'][:]
                 va =  self.Variables.struct['mod_timeseries']['va'][:]
-                self.Variables.sim.velCoef = ut_solv(time, ua, va, lat,
+                self.Variables.sim.velCoef = solve(time, ua, va, lat,
                                   #cnstit=ut_constits, rmin=0.95, notrend=True,
                                   cnstit='auto', rmin=0.95, notrend=True,
                                   method='ols', nodiagn=True, linci=True, conf_int=True)
@@ -253,14 +252,14 @@ class Validation:
             lat = self.Variables.struct['lat']
             el = self.Variables.struct['mod_timeseries']['elev'][:]
 
-            self.Variables.sim.elCoef = ut_solv(time, el, [], lat,
+            self.Variables.sim.elCoef = solve(time, el, [], lat,
                              #cnstit=ut_constits, rmin=0.95, notrend=True,
                              cnstit='auto', rmin=0.95, notrend=True,
                              method='ols', nodiagn=True, linci=True, conf_int=True)
             if self.Variables._obstype=='adcp':
                 ua = self.Variables.struct['mod_timeseries']['ua'][:]
                 va = self.Variables.struct['mod_timeseries']['va'][:]
-                self.Variables.sim.velCoef = ut_solv(time, ua, va, lat,
+                self.Variables.sim.velCoef = solve(time, ua, va, lat,
                                   #cnstit=ut_constits, rmin=0.95, notrend=True,
                                   cnstit='auto', rmin=0.95, notrend=True,
                                   method='ols', nodiagn=True, linci=True, conf_int=True)


### PR DESCRIPTION
It seems utide has changed the function names for solving and reconstructing tides from ut_solv and ut_reconstr to solve and reconstruct. I've fixed all instances of ut_solv and ut_reconstr in PySeidon.

I also removed the redundant imports in pyseidon/tidegaugeClass/tidegaugeClass.py and pyseidon/fvcomClass/fvcomClass.py but I haven't checked whether that breaks anything. I couldn't see how they were being used in those classes...

 Finally, I adjusted the docstrings to match the new function names.
